### PR TITLE
Add HEP info from dept computing SharePoint site

### DIFF
--- a/docs/hep/index.md
+++ b/docs/hep/index.md
@@ -1,6 +1,6 @@
 # High-Energy Physics (HEP)
 
-For IT support in the HEP group please e-mail <a href="mailto:support@hep.ucl.ac.uk">support@hep.ucl.ac.uk</a>.
+For IT support in the HEP group please e-mail [support@hep.ucl.ac.uk](mailto:support@hep.ucl.ac.uk).
 
 ## HEP computing information
 
@@ -11,7 +11,7 @@ Information for members of the HEP group can be found on the [HEP Computing Wiki
 
 ## New accounts
 
-To request a new account, e-mail <a href="mailto:support@hep.ucl.ac.uk">support@hep.ucl.ac.uk</a> stating:
+To request a new account, e-mail [support@hep.ucl.ac.uk](mailto:support@hep.ucl.ac.uk) stating:
 
 - the full name and e-mail address of the person needing the account;
 - the role of the account holder (e.g. new academic or postdoc, PhD student, project or summer student);

--- a/docs/hep/index.md
+++ b/docs/hep/index.md
@@ -1,8 +1,21 @@
 # High-Energy Physics (HEP)
 
-Information for members of the HEP group can be found on the [HEP Computing Wiki](https://www.hep.ucl.ac.uk/twiki/bin/view/Computing). If you don't already have access you should click `TWikiRegistration` on the login page and fill in the registration form, including:
+For IT support in the HEP group please e-mail <a href="mailto:support@hep.ucl.ac.uk">support@hep.ucl.ac.uk</a>.
+
+## HEP computing information
+
+Information for members of the HEP group can be found on the [HEP Computing Wiki](https://www.hep.ucl.ac.uk/twiki/bin/view/Computing). If you don't already have access you should click `TWikiRegistration` on the login page and fill in the registration form. Registrations are dealt with by the support team so you will have to wait a while for us to approve your account. To help us deal with your application quickly it helps if you include:
 
 - your UCL e-mail address if you have one;
 - a brief statement of your role and/or supervisor in the "comment" field so we know you are part of the HEP group.
 
-For IT support in the HEP group please e-mail support@hep.ucl.ac.uk.
+## New accounts
+
+To request a new account, e-mail <a href="mailto:support@hep.ucl.ac.uk">support@hep.ucl.ac.uk</a> stating:
+
+- the full name and e-mail address of the person needing the account;
+- the role of the account holder (e.g. new academic or postdoc, PhD student, project or summer student);
+- the supervisor or line manager of the account holder;
+- how long the account is needed for (typically a year for a project student, longer for others, but can be extended later);
+- the preferred user name (generally the user's surname, or initial(s) + surname);
+- any groups (e.g. atlas, nemo...) the account should be added to (these can also be added later).


### PR DESCRIPTION
Migrating content so the dept computing SharePoint site can be retired or repurposed for only information that needs to be protected from global access.